### PR TITLE
Bring rubocop-rspec dependency in-house and add generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,13 @@ inherit_gem:
   house_style: rails/rubocop.yml
 ```
 
+`house_style` comes with a Rails generator which can set up both your project root and your RSpec folder to start using the default house styles by default. With `house_style` declared in your Gemfile:
+
+```bash
+$ rails generate house_style:install
+```
+
+This will create `.rubocop.yml` files in your project root and `spec` folders.
 
 ## Development
 

--- a/house_style.gemspec
+++ b/house_style.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'rubocop', '~> 0.35.1'
+  spec.add_dependency 'rubocop-rspec', '~> 1.3.1'
 
   spec.add_development_dependency 'bundler', '~> 1.10'
   spec.add_development_dependency 'rake', '~> 10.0'

--- a/lib/generators/house_style/install_generator.rb
+++ b/lib/generators/house_style/install_generator.rb
@@ -1,0 +1,18 @@
+require 'rails/generators'
+require 'rails/generators/base'
+
+module HouseStyle
+  class InstallGenerator < Rails::Generators::Base
+    def self.source_root
+      @source_root ||= File.expand_path(File.join(File.dirname(__FILE__), 'templates'))
+    end
+
+    def create_root_rubocop_yml
+      copy_file '.rubocop.yml', '.rubocop.yml'
+    end
+
+    def create_rspec_rubocop_yml
+      copy_file '.rspec-rubocop.yml', 'spec/.rubocop.yml'
+    end
+  end
+end

--- a/lib/generators/house_style/templates/.rspec-rubocop.yml
+++ b/lib/generators/house_style/templates/.rspec-rubocop.yml
@@ -1,0 +1,5 @@
+inherit_from: ../.rubocop.yml
+inherit_gem:
+  house_style: rspec/rubocop.yml
+
+require: rubocop-rspec

--- a/lib/generators/house_style/templates/.rubocop.yml
+++ b/lib/generators/house_style/templates/.rubocop.yml
@@ -1,0 +1,2 @@
+inherit_gem:
+  house_style: rails/rubocop.yml

--- a/rspec/rubocop.yml
+++ b/rspec/rubocop.yml
@@ -1,5 +1,7 @@
 inherit_from: ../ruby/rubocop.yml
 
+require: rubocop-rspec
+
 Metrics/LineLength:
   Enabled: false
 Metrics/ModuleLength:


### PR DESCRIPTION
OK, in future I promise to split things like this up into two pull requests, but for now... :smile:

* Add `rubocop-rspec`, which adds extra style checks for RSpec files, as a dependency which is then loaded by the `rspec/rubocop.yml` file for inheritance by projects
* Add a basic generator to start new Rails projects off with a house style implementation