### PR TITLE
Update Rubocop configuration to support new Rails option

### DIFF
--- a/house_style.gemspec
+++ b/house_style.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'rubocop', '~> 0.35.1'
+  spec.add_dependency 'rubocop', '~> 0.36.0'
   spec.add_dependency 'rubocop-rspec', '~> 1.3.1'
 
   spec.add_development_dependency 'bundler', '~> 1.10'

--- a/rails/rubocop.yml
+++ b/rails/rubocop.yml
@@ -1,4 +1,4 @@
 inherit_from: ../ruby/rubocop.yml
 
-AllCops:
-  RunRailsCops: true
+Rails:
+  Enabled: true

--- a/ruby/configuration.yml
+++ b/ruby/configuration.yml
@@ -2,7 +2,6 @@ AllCops:
   DisplayCopNames: true
   DisplayStyleGuide: true
   ExtraDetails: true
-  RunRailsCops: false
   UseCache: true
 
   Include:


### PR DESCRIPTION
Rubocop's configuration has now changed:

`The RunRailsCops config parameter in .rubocop.yml is now obsolete. If someone attempts to use it, config validation will fail with a helpful message. (@alexdowad)`

This configures the house style to use the new configuration options.