### PR TITLE
Add support for rubocop's forthcoming `TargetRubyVersion`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,21 @@
-# 0.2.2
+# CHANGELOG
+
+## 1.0.0
+
+- Increases dependency to Rubocop 0.37.2, which changes how to specify Rails cops and introduces the requirement of a Ruby version in each project's `.rubocop.yml` file. A working value for this value will be inserted when `rails generate house_style:install` is run.
+- Support for turning off cops in the Rails `db/migrate/` folder is improved to a system that should actually work.
+- New cop `Style/FrozenStringLiteralComment` is disabled by default.
+- New cop `Style/SignalException` is supported, using the `semantic` default to best match existing practice.
+
+## 0.2.2
 
 - [FIX] Revert gemspec file selection, as replacement was not correctly including the essential rubocop `.yml` files.
 
-# 0.2.1
+## 0.2.1
 
 - [FIX] Rename generator template files so they are included in gem release.
 
-# 0.2.0
+## 0.2.0
 
 - New defaults for `db/migrate` folders in Rails projects.
 - Rails projects using `house_style` can now use a Rails generator to install the relevant house style configurations:
@@ -14,10 +23,10 @@
     - `{Rails.root}/spec/.rubocop.yml` loads tweaked config for RSpec folders, including use of the `rubocop-rspec` plugin
     - `{Rails.root}/db/migrate/.rubocop.yml` ignores key rules for compatibility with Rails-generated migrations, etc.
 
-# 0.1.1
+## 0.1.1
 
 - New `rspec/rubocop.yml` defaults.
 
-# 0.1.0
+## 0.1.0
 
 - Initial release

--- a/house_style.gemspec
+++ b/house_style.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = 'house_style'
-  spec.version       = '0.2.2'
+  spec.version       = '1.0.0'
   spec.authors       = ['Scott Matthewman']
   spec.email         = ['scott@altmetric.com']
 
@@ -16,8 +16,8 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'rubocop', '~> 0.36.0'
-  spec.add_dependency 'rubocop-rspec', '~> 1.3.1'
+  spec.add_dependency 'rubocop', '~> 0.37.2'
+  spec.add_dependency 'rubocop-rspec', '~> 1.4.0'
 
   spec.add_development_dependency 'bundler', '~> 1.10'
   spec.add_development_dependency 'rake', '~> 10.0'

--- a/lib/generators/house_style/install_generator.rb
+++ b/lib/generators/house_style/install_generator.rb
@@ -8,15 +8,15 @@ module HouseStyle
     end
 
     def create_root_rubocop_yml
-      copy_file 'rubocop.yml', '.rubocop.yml'
+      template 'rubocop.yml', '.rubocop.yml'
     end
 
     def create_rspec_rubocop_yml
-      copy_file 'rspec-rubocop.yml', 'spec/.rubocop.yml'
+      template 'rspec-rubocop.yml', 'spec/.rubocop.yml'
     end
 
     def create_db_migrate_rubocop_yml
-      copy_file 'db_migrate_rubocop.yml', 'db/migrate/.rubocop.yml'
+      template 'db_migrate_rubocop.yml', 'db/migrate/.rubocop.yml'
     end
   end
 end

--- a/lib/generators/house_style/install_generator.rb
+++ b/lib/generators/house_style/install_generator.rb
@@ -8,7 +8,7 @@ module HouseStyle
     end
 
     def create_root_rubocop_yml
-      template 'rubocop.yml', '.rubocop.yml'
+      template 'rubocop.yml', '.rubocop.yml', assigns: { ruby_version: ruby_version }
     end
 
     def create_rspec_rubocop_yml
@@ -17,6 +17,13 @@ module HouseStyle
 
     def create_db_migrate_rubocop_yml
       template 'db_migrate_rubocop.yml', 'db/migrate/.rubocop.yml'
+    end
+
+    private
+
+    def ruby_version
+      major, minor, _ = RUBY_VERSION.split('.')
+      "#{major}.#{minor}"
     end
   end
 end

--- a/lib/generators/house_style/templates/rubocop.yml
+++ b/lib/generators/house_style/templates/rubocop.yml
@@ -1,2 +1,5 @@
+AllCops:
+  TargetRubyVersion: <%= RUBY_VERSION %>
+
 inherit_gem:
   house_style: rails/rubocop.yml

--- a/lib/generators/house_style/templates/rubocop.yml
+++ b/lib/generators/house_style/templates/rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: <%= RUBY_VERSION %>
+  TargetRubyVersion: <%= ruby_version %>
 
 inherit_gem:
   house_style: rails/rubocop.yml

--- a/rails/db_migrate.yml
+++ b/rails/db_migrate.yml
@@ -1,24 +1,16 @@
 Metrics/ClassLength:
-  Exclude:
-    - db/migrate/*.rb
+  Enabled: false
 Metrics/LineLength:
-  Exclude:
-    - db/migrate/*.rb
+  Enabled: false
 Metrics/MethodLength:
-  Exclude:
-    - db/migrate/*.rb
+  Enabled: false
 Style/BlockDelimiters:
-  Exclude:
-    - db/migrate/*.rb
+  Enabled: false
 Style/Documentation:
-  Exclude:
-    - db/migrate/*.rb
+  Enabled: false
 Style/EmptyLineBetweenDefs:
-  Exclude:
-    - db/migrate/*.rb
+  Enabled: false
 Style/StringLiterals:
-  Exclude:
-    - db/migrate/*.rb
+  Enabled: false
 Metrics/AbcSize:
-  Exclude:
-    - db/migrate/*.rb
+  Enabled: false

--- a/rspec/rubocop.yml
+++ b/rspec/rubocop.yml
@@ -6,6 +6,8 @@ Metrics/LineLength:
   Enabled: false
 Metrics/ModuleLength:
   Enabled: false
+RSpec/NotToNot:
+  AcceptedMethod: to_not
 Style/BlockDelimiters:
   Exclude:
     - spec/factories/**/*.rb

--- a/ruby/style.yml
+++ b/ruby/style.yml
@@ -36,6 +36,8 @@ Style/EmptyLineBetweenDefs:
   AllowAdjacentOneLineDefs: true
 Style/Encoding:
   EnforcedStyle: when_needed
+Style/FrozenStringLiteralComment:
+  Enabled: false
 Style/GuardClause:
   MinBodyLength: 3
 Style/HashSyntax:
@@ -52,6 +54,8 @@ Style/NonNilCheck:
   IncludeSemanticChanges: true
 Style/NumericLiterals:
   MinDigits: 6
+Style/SignalException:
+  EnforcedStyle: semantic
 Style/StringLiterals:
   Enabled: false
 Style/StringMethods:


### PR DESCRIPTION
The next release of rubocop will require an explicit declaration of which ruby version is being supported within the project's `.rubocop.yml` file, to ensure that the correct parser etc. is being used.

The variations between ruby versions are more about getting the most accurate parser output, as well as identifying version-specific enhancements. In general, our rules settings should be agnostic about the ruby version, so we'll proceed on the basis that it's best for each project to set its own explicit ruby version.

We can include this prior to the new version's release, as its inclusion will just be ignored by the current version of rubocop.

To support this, we switch the generator to treat the stored YAML files as ERb-enhanced templates, then use the RUBY_VERSION of the currently running instance of Ruby to declare the intended ruby version. Rbenv or RVM will generally ensure that this constant is the same as the version cited in `.ruby-version`.

Existing apps using `house_style` can rerun the generators (and merge any changes if needed) or add the ruby version manually.