### PR TITLE
Only add `db/migrate/.rubocop.yml` if `db/` exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## master
+
+- The generator will no longer create `db/migrate/.rubocop.yml` if the Rails `db/` is not present.
+
 ## 1.0.0
 
 - Increases dependency to Rubocop 0.37.2, which changes how to specify Rails cops and introduces the requirement of a Ruby version in each project's `.rubocop.yml` file. A working value for this value will be inserted when `rails generate house_style:install` is run.

--- a/lib/generators/house_style/install_generator.rb
+++ b/lib/generators/house_style/install_generator.rb
@@ -16,14 +16,18 @@ module HouseStyle
     end
 
     def create_db_migrate_rubocop_yml
-      template 'db_migrate_rubocop.yml', 'db/migrate/.rubocop.yml'
+      template 'db_migrate_rubocop.yml', 'db/migrate/.rubocop.yml' if Dir.exist?(db_path)
     end
 
     private
 
     def ruby_version
-      major, minor, _ = RUBY_VERSION.split('.')
+      major, minor, _teeny = RUBY_VERSION.split('.')
       "#{major}.#{minor}"
+    end
+
+    def db_path
+      File.join(Rails.root, 'db')
     end
   end
 end


### PR DESCRIPTION
In a Rails app where the `db/` folder has been deleted (for example, where the app has no internal persistence and is consuming solely API data), do not recreate it in order to add a migration-specific rubocop config file.

Also stop Rubocop reporting a warning when dereferencing the Ruby version.

Closes #9.