### PR TITLE
v1.1.0: Update to Rubocop 0.41.2, remove TargetRubyVersion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 - Hound-CI uses the default rubocop configuration. It will now comment on pull requests only if code is committed that conflicts with the house style. [#11]
 - The generator will no longer create `db/migrate/.rubocop.yml` if the Rails `db/` is not present. [#10]
+- Updated rubocop to 0.41.2 and rubocop-rspec to 1.5. This has some consequences:
+    - a `TargetRubyVersion` is no longer needed, as rubocop defaults to using `.ruby-version` for identifying which version of ruby to parse against. When upgrading, it is safe to remove those lines from the host application's `.rubocop.yml` file.
+    - a new `RSpec/ExampleLength` cop is disabled for now. Nice idea, but if it's a choice between long examples and not being able to deploy because of a style issue, we should take the long examples.
 
 ## 1.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-## master
+## 1.1.0
 
 - Hound-CI uses the default rubocop configuration. It will now comment on pull requests only if code is committed that conflicts with the house style. [#11]
 - The generator will no longer create `db/migrate/.rubocop.yml` if the Rails `db/` is not present. [#10]

--- a/house_style.gemspec
+++ b/house_style.gemspec
@@ -13,11 +13,18 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/altmetric/house_style'
   spec.license       = 'MIT'
 
+  spec.post_install_message = %q{
+If you are updating house_style from version 1.0.0 or older, note that you can
+now remove any reference to TargetRubyVersion in your project's .rubocop.yml
+file. You should specify a .ruby-version file for your entire project, and that
+will be taken into account by rubocop also.
+  }
+
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'rubocop', '~> 0.37.2'
-  spec.add_dependency 'rubocop-rspec', '~> 1.4'
+  spec.add_dependency 'rubocop', '~> 0.41.2'
+  spec.add_dependency 'rubocop-rspec', '~> 1.5'
 
   spec.add_development_dependency 'bundler', '~> 1.10'
   spec.add_development_dependency 'rake', '~> 10.0'

--- a/house_style.gemspec
+++ b/house_style.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = 'house_style'
-  spec.version       = '1.0.0'
+  spec.version       = '1.1.0'
   spec.authors       = ['Scott Matthewman']
   spec.email         = ['scott@altmetric.com']
 
@@ -13,12 +13,12 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/altmetric/house_style'
   spec.license       = 'MIT'
 
-  spec.post_install_message = %q{
+  spec.post_install_message = <<-ENDOFMESSAGE
 If you are updating house_style from version 1.0.0 or older, note that you can
 now remove any reference to TargetRubyVersion in your project's .rubocop.yml
 file. You should specify a .ruby-version file for your entire project, and that
 will be taken into account by rubocop also.
-  }
+  ENDOFMESSAGE
 
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.require_paths = ['lib']

--- a/lib/generators/house_style/install_generator.rb
+++ b/lib/generators/house_style/install_generator.rb
@@ -8,7 +8,7 @@ module HouseStyle
     end
 
     def create_root_rubocop_yml
-      template 'rubocop.yml', '.rubocop.yml', assigns: { ruby_version: ruby_version }
+      template 'rubocop.yml', '.rubocop.yml'
     end
 
     def create_rspec_rubocop_yml
@@ -20,11 +20,6 @@ module HouseStyle
     end
 
     private
-
-    def ruby_version
-      major, minor, _teeny = RUBY_VERSION.split('.')
-      "#{major}.#{minor}"
-    end
 
     def db_path
       File.join(Rails.root, 'db')

--- a/lib/generators/house_style/templates/rubocop.yml
+++ b/lib/generators/house_style/templates/rubocop.yml
@@ -1,5 +1,2 @@
-AllCops:
-  TargetRubyVersion: <%= ruby_version %>
-
 inherit_gem:
   house_style: rails/rubocop.yml

--- a/rspec/rubocop.yml
+++ b/rspec/rubocop.yml
@@ -6,8 +6,10 @@ Metrics/LineLength:
   Enabled: false
 Metrics/ModuleLength:
   Enabled: false
+RSpec/ExampleLength:
+  Enabled: false
 RSpec/NotToNot:
-  AcceptedMethod: to_not
+  EnforcedStyle: to_not
 Style/BlockDelimiters:
   Exclude:
     - spec/factories/**/*.rb


### PR DESCRIPTION
Updating to v0.41.2 allows us to remove the code from the Rails generator that manually calculates the `TargetRubyVersion`. Rubocop now defaults to whatever version of ruby is specified in `.ruby-version`.

It is possible that some flavours of Ruby (e.g., some JRuby versions) have incompatible `.ruby-version` files that Rubocop cannot parse. In those cases, the `TargetRubyVersion` can still be used and will take precedence -- but that need not be the case for the default usage.

In terms of changes to cops:
* RSpec/NotToNot has a changed configuration parameter, but as long as projects do not attempt to override it the change should be seamless
* New cop RSpec/ExampleLength has been disabled

There are some additional new cops, and some other cops have had their defaults tweaked. If, upon upgrading to v1.1, users find that these new cops are not practical, we should do the usual thing:

1) Override in local `.rubocop.yml` files
2) Raise a pull request for changes which should be considered for inclusion in the central house styles.