### PR TITLE
Remove checks on generated and third party files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## master
+
+- Exclude `/bin`, `/vendor` and `db/schema.rb` from ever being checked by rubocop in Rails projects
+
 ## 1.1.0
 
 - Hound-CI uses the default rubocop configuration. It will now comment on pull requests only if code is committed that conflicts with the house style. [#11]

--- a/rails/rubocop.yml
+++ b/rails/rubocop.yml
@@ -1,4 +1,7 @@
 inherit_from: ../ruby/rubocop.yml
-
+Exclude:
+  - bin/*
+  - vendor/**/*
+  - db/schema.rb
 Rails:
   Enabled: true


### PR DESCRIPTION
When code is generated or supplied by third parties, we should not trigger any rubocop style checks, since we are not in a position to make alterations to the code without the risk of our changes being overwritten the next time it is generated. For example, binstubs in `/bin`, the Ruby-based `db/schema.rb` and any vendorized gems in `/vendor`.

We exclude these locations from any and all rubocop checks.