### PR TITLE
Update to rubocop and rubocop-rspec, fix exclusions, bump to v1.1.1

### DIFF
--- a/house_style.gemspec
+++ b/house_style.gemspec
@@ -23,7 +23,7 @@ will be taken into account by rubocop also.
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'rubocop', '~> 0.41.2'
+  spec.add_dependency 'rubocop', '~> 0.42.0'
   spec.add_dependency 'rubocop-rspec', '~> 1.5'
 
   spec.add_development_dependency 'bundler', '~> 1.10'

--- a/house_style.gemspec
+++ b/house_style.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = 'house_style'
-  spec.version       = '1.1.0'
+  spec.version       = '1.1.1'
   spec.authors       = ['Scott Matthewman']
   spec.email         = ['scott@altmetric.com']
 
@@ -24,7 +24,7 @@ will be taken into account by rubocop also.
   spec.require_paths = ['lib']
 
   spec.add_dependency 'rubocop', '~> 0.42.0'
-  spec.add_dependency 'rubocop-rspec', '~> 1.5'
+  spec.add_dependency 'rubocop-rspec', '~> 1.6'
 
   spec.add_development_dependency 'bundler', '~> 1.10'
   spec.add_development_dependency 'rake', '~> 10.0'

--- a/rails/rubocop.yml
+++ b/rails/rubocop.yml
@@ -1,7 +1,8 @@
 inherit_from: ../ruby/rubocop.yml
-Exclude:
-  - bin/*
-  - vendor/**/*
-  - db/schema.rb
+AllCops:
+  Exclude:
+    - bin/**/*
+    - vendor/**/*
+    - db/schema.rb
 Rails:
   Enabled: true


### PR DESCRIPTION
Rubocop 0.42 no longer allows dangling `Except` definitions, so these need to be declared within an `AllCops` heading. The Rails config file repeats the values set in the default Ruby config, because these arrays are not additive.