### PR TITLE
1.3.1: Lock to v0.48.x

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,3 +3,7 @@
 # See the [README](README.md) for instructions on using `house_style`
 # style settings from within your own projects
 inherit_from: ruby/rubocop.yml
+
+Style/IndentHeredoc:
+  Exclude:
+    - house_style.gemspec

--- a/house_style.gemspec
+++ b/house_style.gemspec
@@ -1,10 +1,11 @@
 # coding: utf-8
+
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = 'house_style'
-  spec.version       = '1.3.0'
+  spec.version       = '1.3.1'
   spec.authors       = ['Scott Matthewman']
   spec.email         = ['scott@altmetric.com']
 
@@ -23,8 +24,8 @@ will be taken into account by rubocop also.
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'rubocop', '~> 0.46'
-  spec.add_dependency 'rubocop-rspec', '~> 1.8'
+  spec.add_dependency 'rubocop', '~> 0.48', '< 0.49'
+  spec.add_dependency 'rubocop-rspec', '~> 1.15'
 
   spec.add_development_dependency 'bundler', '~> 1.10'
   spec.add_development_dependency 'rake', '~> 11.0'

--- a/rspec/rubocop.yml
+++ b/rspec/rubocop.yml
@@ -2,6 +2,8 @@ inherit_from: ../ruby/rubocop.yml
 
 require: rubocop-rspec
 
+Metrics/BlockLength:
+  Enabled: false
 Metrics/LineLength:
   Enabled: false
 Metrics/ModuleLength:


### PR DESCRIPTION
The YAML files in `house_style` need tweaking before working with Rubocop 0.49.0 (released 2017-05-24). 

Also update `rubocop-rspec` dependency and prevent long methods in tests from triggering a violation.