### PR TITLE
Add rubocop 0.49 support

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,6 +4,6 @@
 # style settings from within your own projects
 inherit_from: ruby/rubocop.yml
 
-Style/IndentHeredoc:
+Layout/IndentHeredoc:
   Exclude:
     - house_style.gemspec

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 1.4.0
+
+- Update and lock rubocop to 0.49. That way we prevent house_style to use newer version before it being updated and compatible before.
+
 ## 1.3.1
 
 - Lock rubocop to 0.48, the YAML files in house_style need tweaking before working with Rubocop 0.49.0.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,18 @@
 # CHANGELOG
 
+## 1.3.1
+
+- Lock rubocop to 0.48, the YAML files in house_style need tweaking before working with Rubocop 0.49.0.
+- Prevent long methods in tests from triggering a violation.
+
 ## 1.3.0
 
-- updated rubocop to 0.46.0
+- Updated rubocop to 0.46.0
 - Exclude `lib/tasks/cucumber.rake`, which is not intended to be edited.
 
 ## 1.2.0
 
-- updated rubocop to 0.45.0 and rubocop-rspec to 1.8.
+- Updated rubocop to 0.45.0 and rubocop-rspec to 1.8.
 - Exclude `/bin`, `/vendor` and `db/schema.rb` from ever being checked by rubocop in Rails projects
 
 ## 1.1.0

--- a/house_style.gemspec
+++ b/house_style.gemspec
@@ -24,8 +24,8 @@ will be taken into account by rubocop also.
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'rubocop', '~> 0.48', '< 0.49'
-  spec.add_dependency 'rubocop-rspec', '~> 1.15'
+  spec.add_dependency 'rubocop', '~> 0.49', '< 0.50'
+  spec.add_dependency 'rubocop-rspec', '~> 1.16'
 
   spec.add_development_dependency 'bundler', '~> 1.10'
   spec.add_development_dependency 'rake', '~> 11.0'

--- a/house_style.gemspec
+++ b/house_style.gemspec
@@ -5,7 +5,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = 'house_style'
-  spec.version       = '1.3.1'
+  spec.version       = '1.4.0'
   spec.authors       = ['Scott Matthewman']
   spec.email         = ['scott@altmetric.com']
 

--- a/ruby/style.yml
+++ b/ruby/style.yml
@@ -31,8 +31,6 @@ Style/Copyright:
   Enabled: false
 Style/Documentation:
   Enabled: false
-Style/EmptyLineBetweenDefs:
-  AllowAdjacentOneLineDefs: true
 Style/Encoding:
   EnforcedStyle: when_needed
 Style/FrozenStringLiteralComment:
@@ -43,12 +41,8 @@ Style/HashSyntax:
   EnforcedStyle: ruby19_no_mixed_keys
 Style/IfUnlessModifier:
   MaxLineLength: 100
-Style/IndentHash:
-  EnforcedStyle: consistent
 Style/MethodCalledOnDoEndBlock:
   Enabled: true
-Style/MultilineOperationIndentation:
-  Enabled: false
 Style/NonNilCheck:
   IncludeSemanticChanges: true
 Style/NumericLiterals:
@@ -59,3 +53,9 @@ Style/StringLiterals:
   Enabled: false
 Style/StringMethods:
   Enabled: true
+Layout/EmptyLineBetweenDefs:
+  AllowAdjacentOneLineDefs: true
+Layout/IndentHash:
+  EnforcedStyle: consistent
+Layout/MultilineOperationIndentation:
+  Enabled: false


### PR DESCRIPTION
- Rubocop updated and locked to 0.49. Some cops have been renamed and have been updated accordingly.
- Added missing changelog entry.
- Bump version to 1.4.0.