### PR TITLE
Update Rubocop to 0.52

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 1.4.0
+
+- updated rubocop to 0.52.0
+  - rename cops with changed names and remove deprecated definitions.
+
 ## 1.3.0
 
 - updated rubocop to 0.46.0

--- a/house_style.gemspec
+++ b/house_style.gemspec
@@ -5,7 +5,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = 'house_style'
-  spec.version       = '1.3.1'
+  spec.version       = '1.4.0'
   spec.authors       = ['Scott Matthewman']
   spec.email         = ['scott@altmetric.com']
 
@@ -24,7 +24,7 @@ will be taken into account by rubocop also.
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'rubocop', '~> 0.48', '< 0.49'
+  spec.add_dependency 'rubocop', '~> 0.52', '< 0.53'
   spec.add_dependency 'rubocop-rspec', '~> 1.15'
 
   spec.add_development_dependency 'bundler', '~> 1.10'

--- a/rails/db_migrate.yml
+++ b/rails/db_migrate.yml
@@ -8,7 +8,7 @@ Style/BlockDelimiters:
   Enabled: false
 Style/Documentation:
   Enabled: false
-Style/EmptyLineBetweenDefs:
+Layout/EmptyLineBetweenDefs:
   Enabled: false
 Style/StringLiterals:
   Enabled: false

--- a/ruby/style.yml
+++ b/ruby/style.yml
@@ -31,23 +31,19 @@ Style/Copyright:
   Enabled: false
 Style/Documentation:
   Enabled: false
-Style/EmptyLineBetweenDefs:
+Layout/EmptyLineBetweenDefs:
   AllowAdjacentOneLineDefs: true
-Style/Encoding:
-  EnforcedStyle: when_needed
 Style/FrozenStringLiteralComment:
   Enabled: false
 Style/GuardClause:
   MinBodyLength: 3
 Style/HashSyntax:
   EnforcedStyle: ruby19_no_mixed_keys
-Style/IfUnlessModifier:
-  MaxLineLength: 100
-Style/IndentHash:
+Layout/IndentHash:
   EnforcedStyle: consistent
 Style/MethodCalledOnDoEndBlock:
   Enabled: true
-Style/MultilineOperationIndentation:
+Layout/MultilineOperationIndentation:
   Enabled: false
 Style/NonNilCheck:
   IncludeSemanticChanges: true


### PR DESCRIPTION
This change updates to the latest Rubocop, required for support of
Ruby 2.5.0. As part of this update, some of the cops that were
previously in the `Style` namespace are now in the `Layout` namespace,
and the deprecated cops `Style/Encoding` and `Style/IfUnlessModifier`
have been removed.