### PR TITLE
Update Rubocop to 0.63

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 1.5.0
+- updated rubocop to 0.63.1
+
 ## 1.4.0
 
 - updated rubocop to 0.52.0

--- a/house_style.gemspec
+++ b/house_style.gemspec
@@ -5,7 +5,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = 'house_style'
-  spec.version       = '1.4.0'
+  spec.version       = '1.5.0'
   spec.authors       = ['Altmetric', 'Scott Matthewman']
   spec.email         = ['engineering@altmetric.com', 'scott.matthewman@gmail.com']
 
@@ -24,7 +24,7 @@ will be taken into account by rubocop also.
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'rubocop', '~> 0.52', '< 0.53'
+  spec.add_dependency 'rubocop', '~> 0.63', '< 0.64'
   spec.add_dependency 'rubocop-rspec', '~> 1.15'
 
   spec.add_development_dependency 'bundler', '~> 1.10'


### PR DESCRIPTION
This change updates Rubocop to its latest version right now (0.63). We need at least 0.60 to support Ruby 2.6.