### PR TITLE
Removes Include configuration values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 1.5.1
+- [FIX] Remove `Include` values. Since 0.57 `Include` overwrites the hardcoded defaults. All values here are already included in the defaults, so no point in defining them here anymore.
+- [FIX] `SpaceInsideHashLiteralBraces` now belongs to `Layout` instead of `Style`
+- [FIX] Disabling new added cop `Style/AccessModifierDeclarations`. We use inline declarations (`private :foo :bar`) as default in our codebase.
+
 ## 1.5.0
 - updated rubocop to 0.63.1
 

--- a/house_style.gemspec
+++ b/house_style.gemspec
@@ -5,7 +5,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = 'house_style'
-  spec.version       = '1.5.0'
+  spec.version       = '1.5.1'
   spec.authors       = ['Altmetric', 'Scott Matthewman']
   spec.email         = ['engineering@altmetric.com', 'scott.matthewman@gmail.com']
 

--- a/rspec/rubocop.yml
+++ b/rspec/rubocop.yml
@@ -17,7 +17,7 @@ Style/BlockDelimiters:
     - spec/factories/**/*.rb
 Style/Documentation:
   Enabled: false
-Style/SpaceInsideHashLiteralBraces:
+Layout/SpaceInsideHashLiteralBraces:
   Enabled: false
 Style/SymbolProc:
   Exclude:

--- a/ruby/configuration.yml
+++ b/ruby/configuration.yml
@@ -4,23 +4,6 @@ AllCops:
   ExtraDetails: true
   UseCache: true
 
-  Include:
-    - '**/*.gemspec'
-    - '**/*.podspec'
-    - '**/*.jbuilder'
-    - '**/*.rake'
-    - '**/*.opal'
-    - '**/config.ru'
-    - '**/Gemfile'
-    - '**/Rakefile'
-    - '**/Capfile'
-    - '**/Guardfile'
-    - '**/Podfile'
-    - '**/Thorfile'
-    - '**/Vagrantfile'
-    - '**/Berksfile'
-    - '**/Cheffile'
-    - '**/Vagabondfile'
   Exclude:
     - 'vendor/**/*'
     - 'bin/**/*'

--- a/ruby/metrics.yml
+++ b/ruby/metrics.yml
@@ -8,4 +8,3 @@ Metrics/LineLength:
     too short; 120 characters is a good compromise.
 Metrics/MethodLength:
   Max: 10
-

--- a/ruby/style.yml
+++ b/ruby/style.yml
@@ -55,3 +55,5 @@ Style/StringLiterals:
   Enabled: false
 Style/StringMethods:
   Enabled: true
+Style/AccessModifierDeclarations:
+  Enabled: false


### PR DESCRIPTION
Since 0.57 `Include` overwrites the hardcoded defaults. All values here are already included in the defaults, so no point in defining them here anymore.

Also:
- `SpaceInsideHashLiteralBraces` now belongs to `Layout` instead of `Style`
- Disable new added cop `Style/AccessModifierDeclarations`. We use inline declarations (`private :foo :bar`) as default in our codebase.