### PR TITLE
Support Rubocop until 0.74

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # CHANGELOG
 
+## 1.6.0
+- [FIX] Require Rubocop higher than 0.49 to fix security issue: https://nvd.nist.gov/vuln/detail/CVE-2017-8418
+- [FIX] Rename `IndentHash` to `IndentFirstHashElement`, and require Rubocop 0.68 or higher because of this change.
+- Rails cops are now split into a different gem `rubocop-rails` that we include by default.
+- Disable new Rails cops InverseOf & HasManyOrHasOneDependent.
+- Exclude spec files for Lint/AmbiguousBlockAssociation as recommended in https://github.com/rubocop-hq/rubocop/issues/4222#issuecomment-290655562
+- Exclude specific rake configuration file for RSpec/ContextWording.
+- Specify `indented` as the default value for `IndentFirstArrayElement`.
+- Enforce `single_quotes` for `StringLiterals` by default.
+
+
 ## 1.5.1
 - [FIX] Remove `Include` values. Since 0.57 `Include` overwrites the hardcoded defaults. All values here are already included in the defaults, so no point in defining them here anymore.
 - [FIX] `SpaceInsideHashLiteralBraces` now belongs to `Layout` instead of `Style`

--- a/house_style.gemspec
+++ b/house_style.gemspec
@@ -5,7 +5,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = 'house_style'
-  spec.version       = '1.5.1'
+  spec.version       = '1.6.0'
   spec.authors       = ['Altmetric', 'Scott Matthewman']
   spec.email         = ['engineering@altmetric.com', 'scott.matthewman@gmail.com']
 
@@ -24,7 +24,8 @@ will be taken into account by rubocop also.
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'rubocop', '~> 0.63', '< 0.64'
+  spec.add_dependency 'rubocop', '>= 0.68', '< 0.75'
+  spec.add_dependency 'rubocop-rails', '~> 2.3'
   spec.add_dependency 'rubocop-rspec', '~> 1.15'
 
   spec.add_development_dependency 'bundler', '~> 1.10'

--- a/rails/rubocop.yml
+++ b/rails/rubocop.yml
@@ -7,3 +7,9 @@ AllCops:
     - lib/tasks/cucumber.rake
 Rails:
   Enabled: true
+Rails/InverseOf:
+  Enabled: false
+Rails/HasManyOrHasOneDependent:
+  Enabled: false
+
+require: rubocop-rails

--- a/rspec/rubocop.yml
+++ b/rspec/rubocop.yml
@@ -24,3 +24,9 @@ Style/SymbolProc:
     - spec/factories/**/*.rb
 Style/WordArray:
   Enabled: false
+Lint/AmbiguousBlockAssociation:
+  Exclude:
+    - spec/**/*
+RSpec/ContextWording:
+  Exclude:
+    - spec/support/shared_contexts/rake.rb

--- a/ruby/style.yml
+++ b/ruby/style.yml
@@ -39,12 +39,16 @@ Style/GuardClause:
   MinBodyLength: 3
 Style/HashSyntax:
   EnforcedStyle: ruby19_no_mixed_keys
-Layout/IndentHash:
+Layout/IndentFirstArrayElement:
+  EnforcedStyle: consistent
+Layout/IndentFirstHashElement:
   EnforcedStyle: consistent
 Style/MethodCalledOnDoEndBlock:
   Enabled: true
 Layout/MultilineOperationIndentation:
   Enabled: false
+Layout/MultilineMethodCallIndentation:
+  EnforcedStyle: indented
 Style/NonNilCheck:
   IncludeSemanticChanges: true
 Style/NumericLiterals:
@@ -52,7 +56,8 @@ Style/NumericLiterals:
 Style/SignalException:
   EnforcedStyle: semantic
 Style/StringLiterals:
-  Enabled: false
+  EnforcedStyle: 'single_quotes'
+  Enabled: true
 Style/StringMethods:
   Enabled: true
 Style/AccessModifierDeclarations:


### PR DESCRIPTION
This fix the security issue https://nvd.nist.gov/vuln/detail/CVE-2017-8418 and supports Rubocop to the latest version (0.74), adapting cops and configuration accordingly.