### PR TITLE
Add new rubocop plugins (performance & rake)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,7 +3,3 @@
 # See the [README](README.md) for instructions on using `house_style`
 # style settings from within your own projects
 inherit_from: ruby/rubocop.yml
-
-Style/IndentHeredoc:
-  Exclude:
-    - house_style.gemspec

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
-language: ruby
+language:
+cache: bundler
 rvm:
-  - 2.2.2
-before_install: gem install bundler -v 1.10.6
+  - 2.6
+  - 2.7
+  - 3.0
+before_install: gem install bundler -v 2.2.18

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # CHANGELOG
 
+## 2.0.0
+### New features
+
+- Add new rubocop extensions: rubocop-performance & rubocop-rake. Both enabled by default on Ruby configuration.
+
+### Bug fixes
+
+- Restrict extensions versions to avoid introducing new cops in the apps depending on house_style without previously configuing them here.
+- Exclude most Rails default configuration files for our cops to decrease the number of conflicts during Rails upgrades.
+
+### Changes
+
+- Upgrade development dependencies: Bundler & Rake. 
+- Upgrade rubocop to 1.15.0, rubocop-rails to 2.10.1 and rubocop-rspec to 2.3.0.
+- Remove old pre-1.0 post-install message
+
 ## 1.6.0
 - [FIX] Require Rubocop higher than 0.49 to fix security issue: https://nvd.nist.gov/vuln/detail/CVE-2017-8418
 - [FIX] Rename `IndentHash` to `IndentFirstHashElement`, and require Rubocop 0.68 or higher because of this change.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,10 @@
 
 ### Changes
 
-- Upgrade development dependencies: Bundler & Rake. 
+- Update Travis CI configuration and add a default Rake task (rubocop)
+- Upgrade development dependencies: Bundler & Rake.
 - Upgrade rubocop to 1.15.0, rubocop-rails to 2.10.1 and rubocop-rspec to 2.3.0.
-- Remove old pre-1.0 post-install message
+- Remove old pre-1.0 post-install message.
 
 ## 1.6.0
 - [FIX] Require Rubocop higher than 0.49 to fix security issue: https://nvd.nist.gov/vuln/detail/CVE-2017-8418

--- a/Rakefile
+++ b/Rakefile
@@ -1,1 +1,9 @@
 require 'bundler/gem_tasks'
+require 'rubocop/rake_task'
+
+desc 'Run rubocop'
+task :rubocop do
+  RuboCop::RakeTask.new
+end
+
+task default: :rubocop

--- a/house_style.gemspec
+++ b/house_style.gemspec
@@ -21,6 +21,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'rubocop-rails', '~> 2.10'
   spec.add_dependency 'rubocop-rspec', '~> 2.3'
 
-  spec.add_development_dependency 'bundler', '~> 1.10'
-  spec.add_development_dependency 'rake', '~> 11.0'
+  spec.add_development_dependency 'bundler', '~> 2.0'
+  spec.add_development_dependency 'rake', '~> 13.0'
 end

--- a/house_style.gemspec
+++ b/house_style.gemspec
@@ -1,6 +1,4 @@
-# coding: utf-8
-
-lib = File.expand_path('../lib', __FILE__)
+lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
@@ -18,7 +16,9 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'rubocop', '~> 1.15'
+  spec.add_dependency 'rubocop-performance', '~> 1.11'
   spec.add_dependency 'rubocop-rails', '~> 2.10'
+  spec.add_dependency 'rubocop-rake', '< 1.0'
   spec.add_dependency 'rubocop-rspec', '~> 2.3'
 
   spec.add_development_dependency 'bundler', '~> 2.0'

--- a/house_style.gemspec
+++ b/house_style.gemspec
@@ -15,11 +15,11 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'rubocop', '~> 1.15'
-  spec.add_dependency 'rubocop-performance', '~> 1.11'
-  spec.add_dependency 'rubocop-rails', '~> 2.10'
+  spec.add_dependency 'rubocop', '>= 1.0', '< 1.16'
+  spec.add_dependency 'rubocop-performance', '~> 1.11.3'
+  spec.add_dependency 'rubocop-rails', '~> 2.10.1'
   spec.add_dependency 'rubocop-rake', '< 1.0'
-  spec.add_dependency 'rubocop-rspec', '~> 2.3'
+  spec.add_dependency 'rubocop-rspec', '~> 2.3.0'
 
   spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'rake', '~> 13.0'

--- a/performance/default_rules.yml
+++ b/performance/default_rules.yml
@@ -1,0 +1,32 @@
+Performance/AncestorsInclude:
+  Enabled: true
+Performance/BigDecimalWithNumericArgument:
+  Enabled: true
+Performance/BlockGivenWithExplicitBlock:
+  Enabled: true
+Performance/CollectionLiteralInLoop:
+  Enabled: true
+Performance/ConstantRegexp:
+  Enabled: true
+Performance/MapCompact:
+  Enabled: true
+Performance/MethodObjectAsBlock:
+  Enabled: true
+Performance/RedundantEqualityComparisonBlock:
+  Enabled: true
+Performance/RedundantSortBlock:
+  Enabled: true
+Performance/RedundantSplitRegexpArgument:
+  Enabled: true
+Performance/RedundantStringChars:
+  Enabled: true
+Performance/ReverseFirst:
+  Enabled: true
+Performance/SortReverse:
+  Enabled: true
+Performance/Squeeze:
+  Enabled: true
+Performance/StringInclude:
+  Enabled: true
+Performance/Sum:
+  Enabled: true

--- a/performance/rubocop.yml
+++ b/performance/rubocop.yml
@@ -1,0 +1,4 @@
+inherit_from:
+  - ./default_rules.yml
+
+require: rubocop-performance

--- a/rails/db_migrate.yml
+++ b/rails/db_migrate.yml
@@ -1,6 +1,10 @@
-Metrics/ClassLength:
+Layout/EmptyLineBetweenDefs:
   Enabled: false
 Layout/LineLength:
+  Enabled: false
+Metrics/AbcSize:
+  Enabled: false
+Metrics/ClassLength:
   Enabled: false
 Metrics/MethodLength:
   Enabled: false
@@ -8,9 +12,5 @@ Style/BlockDelimiters:
   Enabled: false
 Style/Documentation:
   Enabled: false
-Layout/EmptyLineBetweenDefs:
-  Enabled: false
 Style/StringLiterals:
-  Enabled: false
-Metrics/AbcSize:
   Enabled: false

--- a/rails/rubocop.yml
+++ b/rails/rubocop.yml
@@ -1,6 +1,7 @@
 inherit_from:
   - ../ruby/rubocop.yml
   - ./default_rules.yml
+  - ./style.yml
 
 AllCops:
   Exclude:

--- a/rails/style.yml
+++ b/rails/style.yml
@@ -1,0 +1,31 @@
+# Exclude Rails default configuration files that offend our cops to avoid
+# conflicts during Rails upgrades
+Layout/SpaceInsideArrayLiteralBrackets:
+  Exclude:
+    - config/environments/production.rb
+
+Rails/FilePath:
+  Exclude:
+    - config/environments/development.rb
+
+Style/GlobalStdStream:
+  Exclude:
+    - config/environments/production.rb
+
+Style/StringLiterals:
+  Exclude:
+    - config/application.rb
+    - config/boot.rb
+    - config/environment.rb
+    - config/environments/development.rb
+    - config/environments/production.rb
+    - config/environments/test.rb
+    - config/initializers/**
+    - config/puma.rb
+    - config.ru
+    - Rakefile
+
+Style/SymbolArray:
+  Exclude:
+    - config/initializers/filter_parameter_logging.rb
+

--- a/rake/rubocop.yml
+++ b/rake/rubocop.yml
@@ -1,0 +1,1 @@
+require: rubocop-rake

--- a/rspec/rubocop.yml
+++ b/rspec/rubocop.yml
@@ -2,12 +2,20 @@ inherit_from: ../ruby/rubocop.yml
 
 require: rubocop-rspec
 
-Metrics/BlockLength:
-  Enabled: false
 Layout/LineLength:
+  Enabled: false
+Layout/SpaceInsideHashLiteralBraces:
+  Enabled: false
+Lint/AmbiguousBlockAssociation:
+  Exclude:
+    - spec/**/*
+Metrics/BlockLength:
   Enabled: false
 Metrics/ModuleLength:
   Enabled: false
+RSpec/ContextWording:
+  Exclude:
+    - spec/support/shared_contexts/rake.rb
 RSpec/ExampleLength:
   Enabled: false
 RSpec/NotToNot:
@@ -17,16 +25,8 @@ Style/BlockDelimiters:
     - spec/factories/**/*.rb
 Style/Documentation:
   Enabled: false
-Layout/SpaceInsideHashLiteralBraces:
-  Enabled: false
 Style/SymbolProc:
   Exclude:
     - spec/factories/**/*.rb
 Style/WordArray:
   Enabled: false
-Lint/AmbiguousBlockAssociation:
-  Exclude:
-    - spec/**/*
-RSpec/ContextWording:
-  Exclude:
-    - spec/support/shared_contexts/rake.rb

--- a/ruby/configuration.yml
+++ b/ruby/configuration.yml
@@ -7,3 +7,6 @@ AllCops:
   Exclude:
     - 'vendor/**/*'
     - 'bin/**/*'
+
+Gemspec/RequiredRubyVersion:
+  Enabled: false

--- a/ruby/rubocop.yml
+++ b/ruby/rubocop.yml
@@ -3,3 +3,5 @@ inherit_from:
   - ./metrics.yml
   - ./style.yml
   - ./default_rules.yml
+  - ../rake/rubocop.yml
+  - ../performance/rubocop.yml

--- a/ruby/style.yml
+++ b/ruby/style.yml
@@ -1,3 +1,23 @@
+Layout/EmptyLineBetweenDefs:
+  AllowAdjacentOneLineDefs: true
+Layout/FirstArrayElementIndentation:
+  EnforcedStyle: consistent
+Layout/FirstHashElementIndentation:
+  EnforcedStyle: consistent
+Layout/MultilineOperationIndentation:
+  Enabled: false
+Layout/MultilineMethodCallIndentation:
+  EnforcedStyle: indented
+Layout/LineLength:
+  Max: 120
+  Details: >-
+    If lines are too short, methods become hard to read because you must
+    constantly jump from line to line. If lines are too long, following
+    the flow can be hard because it becomes harder to scan back and
+    locate the start of the next line. 80 characters is generally a bit
+    too short; 120 characters is a good compromise.
+Style/AccessModifierDeclarations:
+  Enabled: false
 Style/BlockDelimiters:
   EnforcedStyle: semantic
   FunctionalMethods:
@@ -25,32 +45,14 @@ Style/Copyright:
   Enabled: false
 Style/Documentation:
   Enabled: false
-Layout/EmptyLineBetweenDefs:
-  AllowAdjacentOneLineDefs: true
 Style/FrozenStringLiteralComment:
   Enabled: false
 Style/GuardClause:
   MinBodyLength: 3
 Style/HashSyntax:
   EnforcedStyle: ruby19_no_mixed_keys
-Layout/FirstArrayElementIndentation:
-  EnforcedStyle: consistent
-Layout/FirstHashElementIndentation:
-  EnforcedStyle: consistent
 Style/MethodCalledOnDoEndBlock:
   Enabled: true
-Layout/MultilineOperationIndentation:
-  Enabled: false
-Layout/MultilineMethodCallIndentation:
-  EnforcedStyle: indented
-Layout/LineLength:
-  Max: 120
-  Details: >-
-    If lines are too short, methods become hard to read because you must
-    constantly jump from line to line. If lines are too long, following
-    the flow can be hard because it becomes harder to scan back and
-    locate the start of the next line. 80 characters is generally a bit
-    too short; 120 characters is a good compromise.
 Style/NonNilCheck:
   IncludeSemanticChanges: true
 Style/NumericLiterals:
@@ -62,5 +64,3 @@ Style/StringLiterals:
   Enabled: true
 Style/StringMethods:
   Enabled: true
-Style/AccessModifierDeclarations:
-  Enabled: false


### PR DESCRIPTION
Added these new rubocop plugins by default when using the Ruby configuration.

Also:
- Bump development dependencies (rake & bundler)
- Restrict plugin versions to avoid finding new cops on apps depending on this gem
- Exclude most Rails default configuration files from our cops, to make easier Rails upgrades
- Adapt developement rubocop configuration
- Sort cops configuration as alphabetical
- Update Travis CI configuration and add a default Rake task (rubocop)