### PR TITLE
Tweak a couple cops and ignore schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## 2.0.1
+### Bug fixes
+- Ignore other database schemas in /db for Rails apps
+- Disable `RSpec/MultipleExpectations` cop.
+- Tweak `RSpec/MultipleMemoizedHelpers` to 10.
+
 ## 2.0.0
 ### New features
 

--- a/house_style.gemspec
+++ b/house_style.gemspec
@@ -3,7 +3,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = 'house_style'
-  spec.version       = '2.0.0'
+  spec.version       = '2.0.1'
   spec.authors       = ['Altmetric', 'Scott Matthewman']
   spec.email         = ['engineering@altmetric.com', 'scott.matthewman@gmail.com']
 

--- a/rails/rubocop.yml
+++ b/rails/rubocop.yml
@@ -7,7 +7,7 @@ AllCops:
   Exclude:
     - bin/**/*
     - vendor/**/*
-    - db/schema.rb
+    - db/*schema.rb
     - lib/tasks/cucumber.rake
 Rails:
   Enabled: true

--- a/rspec/rubocop.yml
+++ b/rspec/rubocop.yml
@@ -18,6 +18,10 @@ RSpec/ContextWording:
     - spec/support/shared_contexts/rake.rb
 RSpec/ExampleLength:
   Enabled: false
+RSpec/MultipleExpectations:
+  Enabled: false
+RSpec/MultipleMemoizedHelpers:
+  Max: 10
 RSpec/NotToNot:
   EnforcedStyle: to_not
 Style/BlockDelimiters:


### PR DESCRIPTION
We want to ignore schemas when we're using multiple databases on Rails.
Also a couple of convenient tweaks to Rspec cops.