### PR TITLE
Exclude more Rails configuration files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## CURRENT
 
+## 2.3.0
+### Changes
+- Exclude more Rails configuration files affected by rails app:update.
+
 ## 2.2.1
 ### Bug fixes
 - Do not skip features/ directory in the gem when packaging.

--- a/house_style.gemspec
+++ b/house_style.gemspec
@@ -3,7 +3,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = 'house_style'
-  spec.version       = '2.2.1'
+  spec.version       = '2.3.0'
   spec.authors       = ['Altmetric', 'Scott Matthewman']
   spec.email         = ['engineering@altmetric.com', 'scott.matthewman@gmail.com']
 

--- a/ruby/configuration.yml
+++ b/ruby/configuration.yml
@@ -14,6 +14,9 @@ AllCops:
     - tmp/**/*
     - db/*schema.rb
     - config.ru
+    - config/environments/**/*
+    - config/puma.rb
+    - config/spring.rb
 
 Gemspec/RequiredRubyVersion:
   Enabled: false


### PR DESCRIPTION
Added to the Ruby configuration since the exclude option isn't merged between different configurations.