### PR TITLE
Remove RSpec/ExpectActual

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-## CURRENT
+## 3.2.0
 ### Changes
 - Remove RSpec/ExpectActual: Whenever we do routing, there's always false positives, e.g. `expect(post: '/email_updates/123').to route_to('email_updates#create', id: '123')`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## CURRENT
+### Changes
+- Remove RSpec/ExpectActual: Whenever we do routing, there's always false positives, e.g. `expect(post: '/email_updates/123').to route_to('email_updates#create', id: '123')`.
+
 ## 3.1.0
 ### Changes
 - Do not suggest extensions

--- a/house_style.gemspec
+++ b/house_style.gemspec
@@ -3,7 +3,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = 'house_style'
-  spec.version       = '3.1.0'
+  spec.version       = '3.2.0'
   spec.authors       = ['Altmetric', 'Scott Matthewman']
   spec.email         = ['engineering@altmetric.com', 'scott.matthewman@gmail.com']
 

--- a/rspec/rubocop.yml
+++ b/rspec/rubocop.yml
@@ -36,8 +36,6 @@ RSpec/EmptyLineAfterHook:
   Enabled: true
 RSpec/EmptyLineAfterSubject:
   Enabled: true
-RSpec/ExpectActual:
-  Enabled: true
 RSpec/ExpectInHook:
   Enabled: true
 RSpec/ExpectOutput:


### PR DESCRIPTION
Whenever we do routing, there's always false positives. Example:

```ruby 
expect(post: '/email_updates/123').to route_to('email_updates#create', id: '123')
```