### PR TITLE
Fix RSpec/Capybara and RSpec/FactoryBot namespace errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 3.2.1
+### Changes
+- Remove the `RSpec/` prefix from the Capybara and FactoryBot configurations.  These namespaces changes should be hidden until `rubocop-rspec` v3.0 according to https://github.com/rubocop/rubocop-rspec/blob/master/CHANGELOG.md but we are seeing warnings now so we are moving the new namespaces immediately.
+
 ## 3.2.0
 ### Changes
 - Remove RSpec/ExpectActual: Whenever we do routing, there's always false positives, e.g. `expect(post: '/email_updates/123').to route_to('email_updates#create', id: '123')`.

--- a/house_style.gemspec
+++ b/house_style.gemspec
@@ -3,7 +3,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = 'house_style'
-  spec.version       = '3.2.0'
+  spec.version       = '3.2.1'
   spec.authors       = ['Altmetric', 'Scott Matthewman']
   spec.email         = ['engineering@altmetric.com', 'scott.matthewman@gmail.com']
 

--- a/rspec/rubocop.yml
+++ b/rspec/rubocop.yml
@@ -13,11 +13,11 @@ Lint/AmbiguousBlockAssociation:
 Capybara/CurrentPathExpectation:
   Enabled: true
 
-RSpec/FactoryBot/AttributeDefinedStatically:
+FactoryBot/AttributeDefinedStatically:
   Enabled: true
-RSpec/FactoryBot/CreateList:
+FactoryBot/CreateList:
   Enabled: true
-RSpec/FactoryBot/FactoryClassName:
+FactoryBot/FactoryClassName:
   Enabled: true
 
 RSpec/BeEql:

--- a/rspec/rubocop.yml
+++ b/rspec/rubocop.yml
@@ -10,7 +10,7 @@ Lint/AmbiguousBlockAssociation:
   Exclude:
     - spec/**/*
 
-RSpec/Capybara/CurrentPathExpectation:
+Capybara/CurrentPathExpectation:
   Enabled: true
 
 RSpec/FactoryBot/AttributeDefinedStatically:


### PR DESCRIPTION
I started getting an error when I ran rubocop using the latest house_style defaults

`RSpec/Capybara/CurrentPathExpectation has the wrong namespace - should be Capybara`

It looks like something has changed upstream so this change simply applies the namespace change suggested by the error message