### PR TITLE
Add house style for consistent enforced hash shorthand syntax

### DIFF
--- a/house_style.gemspec
+++ b/house_style.gemspec
@@ -3,7 +3,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = 'house_style'
-  spec.version       = '3.2.1'
+  spec.version       = '3.2.2'
   spec.authors       = ['Altmetric', 'Scott Matthewman']
   spec.email         = ['engineering@altmetric.com', 'scott.matthewman@gmail.com']
 

--- a/ruby/rubocop.yml
+++ b/ruby/rubocop.yml
@@ -529,6 +529,7 @@ Style/HashExcept:
   Enabled: true
 Style/HashSyntax:
   EnforcedStyle: ruby19_no_mixed_keys
+  EnforcedShorthandSyntax: consistent
 Style/HashTransformKeys:
   Enabled: true
 Style/HashTransformValues:


### PR DESCRIPTION
### What is this PR?

Ruby 3.x introduced a new syntax option for hashes known as [hash literal values](https://rubystyle.guide//#hash-literal-values).  In response Rubocop introduced a new [`EnforcedShorthandSyntax`](https://docs.rubocop.org/rubocop/cops_style.html#stylehashsyntax) option for the `Style/HashSyntax` cop.  By default this is set to `always`.  That means Rubocop will pass not only hashes where all values can be omitted like so:

```
first = 'foo'
second = 'bar'

# bad
{first: first, second: second}

# good
{first:, second:}
```

The cop will also enforce values to be omitted where possible even when there are values in the hash that cannot be omitted (i.e. where the value does not match the key) like so:

```
first = 'foo'
second = 'bar'
other = 'hello'

# bad
{first: first, second: second, third: other}

# good
{first:, second:, third: other}
```

This PR adjusts the `EnforcedShorthandSyntax` option to `consistent` so that this shorthand will only be enforced where ALL values of the hash are able to be omitted:

```
first = 'foo'
second = 'bar'
other = 'hello'

# bad
{first:, second:, third: other}

# good
{first: first, second: second, third: other}

# good
{first:, second:, other:}
```

### Why?

This change to the `EnforcedShorthandSyntax` option brings its behaviour into line with the other `Style/HashSyntax` Cop we have `EnforcedStyle: ruby19_no_mixed_keys`.  The colon syntax in hashes is effectively another convenient syntax for symbol keys - however you are only allowed to use it if all keys are symbols:

```
# bad
{first: first, second: second, 'third' => other}

# good
{:first => first, :second => second, 'third' => other}

# good
{first: first, second: second, third: third}
```

By adjusting the `EnforcedShorthandSyntax` setting to `consistent` it will prompt you to only use it when all values in the hash can use it.  Much like you can only use the `:` syntax if all keys can utilise it (i.e. all keys are symbols).
