### PR TITLE
Upgrade to RuboCop RSpec 3.x and latest dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # CHANGELOG
 
+## CURRENT
+
+## 4.0.0
+
+### Changes
+
+- Rename deprecated `Naming/PredicateName` cop to `Naming/PredicatePrefix`
+- Upgrade to rubocop-rspec 3.x which extracts FactoryBot and Capybara cops to separate gems
+- Update minimum dependency versions to latest stable releases:
+  - rubocop >= 1.81 (was >= 1.31)
+  - rubocop-performance ~> 1.26 (was ~> 1.11)
+  - rubocop-rails ~> 2.33 (was ~> 2.12)
+  - rubocop-rspec ~> 3.7 (was ~> 2.5)
+  - rubocop-capybara ~> 2.22 (new explicit dependency for rubocop-rspec v3)
+  - rubocop-factory_bot ~> 2.27 (new explicit dependency for rubocop-rspec v3)
+- Update to use new `plugins:` syntax for all RuboCop extensions.
+
 ## 3.2.2
 
 ### Changes
@@ -9,7 +26,7 @@
 ## 3.2.1
 
 ### Changes
-- Remove the `RSpec/` prefix from the Capybara and FactoryBot configurations.  These namespaces changes should be hidden until `rubocop-rspec` v3.0 according to https://github.com/rubocop/rubocop-rspec/blob/master/CHANGELOG.md but we are seeing warnings now so we are moving the new namespaces immediately.
+- Remove the `RSpec/` prefix from the Capybara and FactoryBot configurations. These namespaces changes should be hidden until `rubocop-rspec` v3.0 according to https://github.com/rubocop/rubocop-rspec/blob/master/CHANGELOG.md but we are seeing warnings now so we are moving the new namespaces immediately.
 
 ## 3.2.0
 ### Changes

--- a/house_style.gemspec
+++ b/house_style.gemspec
@@ -3,7 +3,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = 'house_style'
-  spec.version       = '3.2.2'
+  spec.version       = '4.0.0'
   spec.authors       = ['Altmetric', 'Scott Matthewman']
   spec.email         = ['engineering@altmetric.com', 'scott.matthewman@gmail.com']
 
@@ -15,10 +15,12 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(bin|.gitignore|)/}) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'rubocop', '>= 1.31', '< 2.0'
-  spec.add_dependency 'rubocop-performance', '~> 1.11'
-  spec.add_dependency 'rubocop-rails', '~> 2.12'
-  spec.add_dependency 'rubocop-rspec', '~> 2.5'
+  spec.add_dependency 'rubocop', '>= 1.81', '< 2.0'
+  spec.add_dependency 'rubocop-performance', '~> 1.26'
+  spec.add_dependency 'rubocop-rails', '~> 2.32'
+  spec.add_dependency 'rubocop-rspec', '~> 3.7'
+  spec.add_dependency 'rubocop-capybara', '~> 2.22'
+  spec.add_dependency 'rubocop-factory_bot', '~> 2.27'
 
   spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'rake', '~> 13.0'

--- a/lib/generators/house_style/templates/rubocop.yml
+++ b/lib/generators/house_style/templates/rubocop.yml
@@ -1,4 +1,7 @@
 inherit_gem:
   house_style: rails/rubocop.yml
 
-require: rubocop-rspec
+plugins:
+  - rubocop-rspec
+  - rubocop-capybara
+  - rubocop-factory_bot

--- a/performance/rubocop.yml
+++ b/performance/rubocop.yml
@@ -1,4 +1,5 @@
-require: rubocop-performance
+plugins:
+  - rubocop-performance
 
 Performance:
   Exclude:

--- a/rails/rubocop.yml
+++ b/rails/rubocop.yml
@@ -1,4 +1,5 @@
-require: rubocop-rails
+plugins:
+  - rubocop-rails
 
 inherit_from:
   - ../ruby/rubocop.yml

--- a/rspec/rubocop.yml
+++ b/rspec/rubocop.yml
@@ -1,6 +1,9 @@
 inherit_from: ../ruby/rubocop.yml
 
-require: rubocop-rspec
+plugins:
+  - rubocop-rspec
+  - rubocop-capybara
+  - rubocop-factory_bot
 
 Layout/LineLength:
   Enabled: false

--- a/ruby/rubocop.yml
+++ b/ruby/rubocop.yml
@@ -416,7 +416,7 @@ Naming/MethodName:
   Enabled: true
 Naming/MethodParameterName:
   Enabled: true
-Naming/PredicateName:
+Naming/PredicatePrefix:
   Enabled: true
 Naming/VariableName:
   Enabled: true


### PR DESCRIPTION
- Upgrade rubocop-rspec to 3.x (extracts FactoryBot/Capybara to separate gems)
- Update all extensions to use plugins: syntax
- Require RuboCop >= 1.81, rubocop-performance ~> 1.26, rubocop-rails ~> 2.33
- Add explicit dependencies for rubocop-capybara and rubocop-factory_bot
- Rename deprecated Naming/PredicateName to Naming/PredicatePrefix